### PR TITLE
BugFix: Correct size of buckets, even if struct has more than 4 byte

### DIFF
--- a/RTCmemTest/RTCmemTest.ino
+++ b/RTCmemTest/RTCmemTest.ino
@@ -22,8 +22,7 @@ void setup() {
   Serial.begin(115200);
   Serial.println();
   Serial.println("Start");
-  buckets = (sizeof(rtcMem) / 4);
-  if (buckets == 0) buckets = 1;
+  buckets = (sizeof(rtcMem) + 3) / 4;
   Serial.print("Buckets ");
   Serial.println(buckets);
   system_rtc_mem_read(64, &toggleFlag, 4);


### PR DESCRIPTION
Calculation of buckets fixed.
Calculation was only valid for structs in the range from 1 to 4 byte.